### PR TITLE
Explicit declaration of self::$rightname variable

### DIFF
--- a/inc/object.class.php
+++ b/inc/object.class.php
@@ -31,6 +31,8 @@ class PluginGenericobjectObject extends CommonDBTM {
    
    //Internal field counter
    private $cpt = 0;
+   
+   static $rightname = '';
 
    //Get itemtype name
    static function getTypeName($nb=0) {


### PR DESCRIPTION
Some modules (ex. item_ticket.class) of GLPI incorrectly works without explicit declaration of self::$rightname variable.
